### PR TITLE
Update README-windows.txt

### DIFF
--- a/ovirt-guest-agent/README-windows.txt
+++ b/ovirt-guest-agent/README-windows.txt
@@ -32,7 +32,7 @@ right configuration location.
 Running the service:
 --------------------
 
-> python OVirtGuestService.py -install
+> python OVirtGuestService.py install
 > net start OVirtGuestService
 
 Building executable file:


### PR DESCRIPTION
python OVirtGuestService.py install should be without "-" near install to work as expected. Tested on 3.3. and windows 2003 and 2008
